### PR TITLE
Fix canBookmark() crash

### DIFF
--- a/src/FangApp.cpp
+++ b/src/FangApp.cpp
@@ -347,8 +347,8 @@ void FangApp::setBookmark(qint64 id, bool allowBackward)
                                     currentFeed->getNewsList()->newsItemForID(id));
     manager.runSynchronously(&bookmarkOp);
 
-    currentFeed->setBookmark(bookmarkOp.getBookmark());
-    webSocketServer.drawBookmark(currentFeed->getBookmark()->getDbID());
+    currentFeed->setBookmark(bookmarkOp.getBookmark()->getDbID());
+    webSocketServer.drawBookmark(currentFeed->getBookmarkID());
 }
 
 void FangApp::setPin(qint64 id, bool pin)
@@ -603,8 +603,8 @@ void FangApp::markAllAsReadOrUnread(FeedItem *feed, bool read)
 
     // Update UI to bookmark last item in list.
     // NOTE: May lead to bugs if the last news item is not loaded into newsList
-    currentFeed->setBookmark(currentFeed->getNewsList()->last());
-    webSocketServer.drawBookmark(currentFeed->getBookmark()->getDbID());
+    currentFeed->setBookmark(currentFeed->getNewsList()->last()->getDbID());
+    webSocketServer.drawBookmark(currentFeed->getBookmarkID());
 }
 
 void FangApp::setRefreshTimer()

--- a/src/models/FeedItem.cpp
+++ b/src/models/FeedItem.cpp
@@ -18,7 +18,7 @@ FeedItem::FeedItem(QObject *parent) :
     newsList(),
     isUpdating(false),
     unreadCount(0),
-    _bookmark(nullptr),
+    _bookmarkID(-1),
     dropTarget("none"),
     _errorFlag(false),
     isSelected(false),
@@ -48,7 +48,7 @@ FeedItem::FeedItem(qint64 id, const qint32 ordinal, const QString &title, const 
     newsList(),
     isUpdating(false),
     unreadCount(0),
-    _bookmark(nullptr),
+    _bookmarkID(-1),
     dropTarget("none"),
     _errorFlag(false),
     isSelected(false),
@@ -232,20 +232,20 @@ void FeedItem::clearNews()
     newsList.clear();
 }
 
-bool FeedItem::canBookmark(qint64 bookmarkID, bool allowBackward)
+bool FeedItem::canBookmark(qint64 proposedBookmarkID, bool allowBackward)
 {
     // What is this? I don't even.
-    if (bookmarkID < -1) {
+    if (proposedBookmarkID < -1) {
         return false;
     }
     
     // Given no current bookmark, anything will do.
-    if (_bookmark == nullptr) {
+    if (_bookmarkID < 0) {
         return true;
     }
     
     // That's a no-op for you, young man.
-    if (_bookmark->getDbID() == bookmarkID) {
+    if (_bookmarkID == proposedBookmarkID) {
         return false;
     }
     
@@ -255,17 +255,17 @@ bool FeedItem::canBookmark(qint64 bookmarkID, bool allowBackward)
     }
 
     // We asked SQLite to always increase our IDs, remember.
-    return bookmarkID > _bookmark->getDbID();
+    return proposedBookmarkID > _bookmarkID;
 }
 
-void FeedItem::setBookmark(NewsItem* bookmark)
+void FeedItem::setBookmark(qint64 toBookmarkID)
 {
-    qDebug() << "FeedItem::setBookmark to " << (bookmark ? bookmark->getDbID() : -1);
-    if (bookmark == _bookmark) {
+    qDebug() << "FeedItem::setBookmark to " << toBookmarkID;
+    if (toBookmarkID == _bookmarkID) {
         return; // Nothing to do.
     }
     
-    _bookmark = bookmark;
+    _bookmarkID = toBookmarkID;
     emit dataChanged();
 }
 

--- a/src/models/FeedItem.h
+++ b/src/models/FeedItem.h
@@ -140,22 +140,22 @@ public slots:
     
     /**
      * @brief Used to set the bookmark internally.  External classes shouldn't need to call this.
-     * @param bookmark Item to bookmark or nullptr to clear.
+     * @param bookmark Item ID or -1 to clear.t
      */
-    virtual void setBookmark(NewsItem* bookmark);
+    virtual void setBookmark(qint64 toBookmarkID);
     
     /**
      * @param item
      * @param allowBackward
      * @return True if this item can be bookmarked.
      */
-    virtual bool canBookmark(qint64 bookmarkID, bool allowBackward);
+    virtual bool canBookmark(qint64 proposedBookmarkID, bool allowBackward);
     
     /**
-     * @brief Returns the current bookmark or nullptr.
+     * @brief Returns the current bookmark ID or -1 if none.
      * @return 
      */
-    inline NewsItem* getBookmark() { return _bookmark; }
+    inline qint64 getBookmarkID() const { return _bookmarkID; }
     
     /**
      * @brief Detaches the feed ID when this feed is being disconnected.
@@ -253,7 +253,7 @@ private:
     NewsList newsList;
     int isUpdating;
     qint32 unreadCount;
-    NewsItem* _bookmark;
+    qint64 _bookmarkID;
     QString dropTarget;
     bool _errorFlag;
     bool isSelected;

--- a/src/models/LisvelFeedItem.cpp
+++ b/src/models/LisvelFeedItem.cpp
@@ -7,29 +7,22 @@ LisvelFeedItem::LisvelFeedItem(const qint64 id, const qint32 ordinal, const QStr
 {
 }
 
-bool LisvelFeedItem::canBookmark(qint64 bookmarkID, bool allowBackward)
+bool LisvelFeedItem::canBookmark(qint64 proposedBookmarkID, bool allowBackward)
 {
     // You FAIL!
-    if (bookmarkID < -1) {
+    if (proposedBookmarkID < -1) {
         return false;
     }
 
     // Given no current bookmark, anything will do.
-    if (getBookmark() == nullptr) {
+    if (getBookmarkID() < 0) {
         // qDebug() << "canBookmark: yes because no current bookmark";
         return true;
     }
 
     // No change.
-    if (getBookmark()->getDbID() == bookmarkID) {
+    if (getBookmarkID() == proposedBookmarkID) {
         return false;
-    }
-
-    // ASSUMPTION: Since we always start from the bookmark, if the bookmark ID isn't -1 it
-    // must therefore be in the _newsIDs list, my dear Watson.
-    if (getBookmark()->getDbID() < 0) {
-        // qDebug() << "canBookmark: yes because current bookmark has invalid id";
-        return true;
     }
 
     // We can bookmark anything in this situation.
@@ -40,12 +33,12 @@ bool LisvelFeedItem::canBookmark(qint64 bookmarkID, bool allowBackward)
     }
 
     // Compare index of proposed bookmark to index of current bookmark.
-    qsizetype proposedIndex = bookmarkID == -1 ? 0 : getNewsList()->indexForItemID(bookmarkID);
-    qsizetype currentIndex = getNewsList()->indexOf(getBookmark());
+    qsizetype proposedIndex = proposedBookmarkID == -1 ? 0 : getNewsList()->indexForItemID(proposedBookmarkID);
+    qsizetype currentIndex = getNewsList()->indexForItemID(getBookmarkID());
 
     // If the bookmark ID wasn't find
     if (proposedIndex < 0) {
-        qDebug() << "Bookmark ID not found in memory: " << bookmarkID;
+        qDebug() << "Bookmark ID not found in memory: " << proposedBookmarkID;
         return false;
     }
 

--- a/src/models/LisvelFeedItem.h
+++ b/src/models/LisvelFeedItem.h
@@ -24,11 +24,11 @@ public:
     explicit LisvelFeedItem(const qint64 id, const qint32 ordinal, const QString &title, QObject *parent = nullptr);
 
     /**
-     * @param item
+     * @param proposedBookmarkID
      * @param allowBackward
      * @return True if this item can be bookmarked.
      */
-    virtual bool canBookmark(qint64 bookmarkID, bool allowBackward);
+    virtual bool canBookmark(qint64 proposedBookmarkID, bool allowBackward);
 };
 
 #endif // LISVELFEEDITEM_H

--- a/src/operations/LisvelLoadNewsOperation.cpp
+++ b/src/operations/LisvelLoadNewsOperation.cpp
@@ -68,7 +68,7 @@ void LisvelLoadNewsOperation::executeSynchronous()
         }
 
         // Set the bookmark (can be null if there isn't one.)
-        feedItem->setBookmark(bookmark);
+        feedItem->setBookmark(bookmark->getDbID());
 
         // As an optimization, we only want to present *one* list -- an append list.
         // So we rewind our prepend list on top of it, then delete the prepend list.

--- a/src/operations/LoadNewsOperation.cpp
+++ b/src/operations/LoadNewsOperation.cpp
@@ -249,7 +249,7 @@ void LoadNewsOperation::executeSynchronous()
     
     // Set our bookmark.
     if (bookmarkID >= 0) {
-        feedItem->setBookmark(feedItem->getNewsList()->newsItemForID(bookmarkID));
+        feedItem->setBookmark(bookmarkID);
     }
     
     // Set the first known ID.

--- a/src/operations/SetBookmarkOperation.cpp
+++ b/src/operations/SetBookmarkOperation.cpp
@@ -79,7 +79,7 @@ void SetBookmarkOperation::bookmarkFolderFeed(FolderFeedItem* feedFolder)
 void SetBookmarkOperation::bookmarkAllNewsFeed(AllNewsFeedItem* allNews)
 {
     int proposed = allNews->getNewsList()->indexOf(bookmark);
-    int current = allNews->getNewsList()->indexOf(allNews->getBookmark());
+    int current = allNews->getNewsList()->indexForItemID(allNews->getBookmarkID());
     
     Q_ASSERT(proposed != current); // You have to double-check for this before starting this operation.
     

--- a/src/server/WebServer.cpp
+++ b/src/server/WebServer.cpp
@@ -96,8 +96,8 @@ QString WebServer::loadNews(LoadNewsOperation::LoadMode mode)
     FeedItem* currentFeed = FangApp::instance()->getCurrentFeed();
     if (mode == LoadNewsOperation::Initial)  {
         // Bookmark (if needed)
-        if (currentFeed->bookmarksEnabled() && currentFeed->getBookmark()) {
-            qint64 idOfBookmark = currentFeed->getBookmark()->getDbID();
+        if (currentFeed->bookmarksEnabled() && currentFeed->getBookmarkID() >= 0) {
+            qint64 idOfBookmark = currentFeed->getBookmarkID();
             document.insert("bookmark", idOfBookmark);
         }
     }

--- a/src/server/WebServer.h
+++ b/src/server/WebServer.h
@@ -14,6 +14,7 @@ public:
     WebServer(QObject *parent = nullptr);
 
 private:
+
     // Updates a pin in the DB.
     QString updatePinObject(qint64 newsID, bool pinned);
 

--- a/src/server/WebSocketServer.cpp
+++ b/src/server/WebSocketServer.cpp
@@ -124,7 +124,7 @@ void WebSocketServer::drawBookmark(qint64 bookmarkID)
 void WebSocketServer::jumpToBookmark()
 {
     FeedItem* currentFeed = FangApp::instance()->getCurrentFeed();
-    if (!currentFeed->bookmarksEnabled() && currentFeed->getBookmark()) {
+    if (!currentFeed->bookmarksEnabled() && currentFeed->getBookmarkID() >= 0) {
         // Nothing to do!
         return;
     }
@@ -132,7 +132,7 @@ void WebSocketServer::jumpToBookmark()
     // Find the bookmark.
     bool bookmarkLoaded = false;
     for (NewsItem* item : *currentFeed->getNewsList()) {
-        if (currentFeed->getBookmark() == item) {
+        if (currentFeed->getBookmarkID() == item->getDbID()) {
             bookmarkLoaded = true;
             break;
         }


### PR DESCRIPTION
Switches from comparing via object to comparing via ID, as the object we're comparing against may have been deleted.

Closes #180