### PR TITLE
Dim on inactive focus

### DIFF
--- a/qml/Sidebar.qml
+++ b/qml/Sidebar.qml
@@ -75,6 +75,7 @@ Item {
             anchors.leftMargin: 5 * style.scale;
             height: 28 * style.scale;
             asynchronous: true;
+            opacity: style.windowActive ? 1.0 : 0.6;
 
             // Hack to make SVGs render with anti-aliasing
             sourceSize.width: width;

--- a/qml/Style.qml
+++ b/qml/Style.qml
@@ -187,7 +187,13 @@ Item {
             if (platform === "MAC" && !windowActive) return sysPalette.windowText;
             return sysPalette.highlightedText;
         }
-        property color sidebarText: sysPalette.windowText;
+        property color sidebarText: {
+            if (!windowActive) {
+                return Qt.rgba(sysPalette.windowText.r, sysPalette.windowText.g, sysPalette.windowText.b, 0.5);
+            }
+
+            sysPalette.windowText;
+        }
 
         property color sidebarButton: "transparent";
         property color sidebarButtonBorder: Qt.rgba(0, 0, 0, 0.15);
@@ -245,8 +251,8 @@ Item {
             return sysPalette.windowText;
         }
         property color sidebarText: {
-            if (platform === "MAC" && !windowActive) {
-                return "#999";
+            if (!windowActive) {
+                return Qt.rgba(sysPalette.windowText.r, sysPalette.windowText.g, sysPalette.windowText.b, 0.5);
             }
 
             return sysPalette.windowText;


### PR DESCRIPTION
Dims the Fang logo and the sidebar text when the window is out of focus on all platforms